### PR TITLE
Fixes #1

### DIFF
--- a/lib/faraday/raise_pocket_error.rb
+++ b/lib/faraday/raise_pocket_error.rb
@@ -26,7 +26,7 @@ module Faraday
     end
 
     def response_values(env)
-      {:status => env.status, :headers => env.response_headers, :body => env.body}
+      {:status => env[:status], :headers => env[:response_headers], :body => env[:body]}
     end
   end
 end


### PR DESCRIPTION
This fixes #1 by using `env[:something]` instead of `env.something`, since `env` is a Hash.
