### PR TITLE
Bump gem version

### DIFF
--- a/lib/pocket/version.rb
+++ b/lib/pocket/version.rb
@@ -1,3 +1,3 @@
 module Pocket
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
`OAuth#get_result` was not accessible in 0.0.4.
