### PR TITLE
Don't give away your consumer key.

### DIFF
--- a/lib/pocket/configuration.rb
+++ b/lib/pocket/configuration.rb
@@ -10,6 +10,7 @@ module Pocket
       :consumer_key,
       :access_token,
       :endpoint,
+      :redirect_uri,
       :format,
       :user_agent,
       :proxy
@@ -77,6 +78,7 @@ module Pocket
       self.consumer_key   = DEFAULT_CONSUMER_KEY
       self.access_token   = DEFAULT_ACCESS_TOKEN
       self.endpoint       = DEFAULT_ENDPOINT
+      self.redirect_uri   = DEFAULT_REDIRECT_URI
       self.format         = DEFAULT_FORMAT
       self.user_agent     = DEFAULT_USER_AGENT
       self.proxy          = DEFAULT_PROXY

--- a/lib/pocket/oauth.rb
+++ b/lib/pocket/oauth.rb
@@ -3,7 +3,8 @@ module Pocket
   module OAuth
     # Return URL for OAuth authorization
     def authorize_url(options={})
-      params = { redirect_uri: redirect_uri }.merge(options)
+      params = access_token_params.merge(options)
+      params.delete(:consumer_key) # shouldn't be exposed publically
       # Pocket renames `code` to `request_token` for some reason in this call
       params[:request_token] ||= params.delete(:code)
       connection.build_url("/auth/authorize", params).to_s
@@ -11,7 +12,7 @@ module Pocket
 
     # Return a Pocket code
     def get_code(options={})
-      params = access_token_params.merge(:redirect_uri => redirect_uri).merge(options)
+      params = access_token_params.merge(options)
       response = connection.post 'oauth/request', params
       results = Hash[URI.decode_www_form(response.body)]
       code = results['code']
@@ -19,8 +20,6 @@ module Pocket
 
     # Return an access token from authorization
     def get_access_token(code, options={})
-      params = access_token_params.merge(options)
-
       params = access_token_params.merge(:code => code).merge(options)
       response = connection.post 'oauth/authorize', params
       results = Hash[URI.decode_www_form(response.body)]
@@ -29,8 +28,6 @@ module Pocket
 
     # Return result from authorization
     def get_result(code, options={})
-      params = access_token_params.merge(options)
-
       params = access_token_params.merge(:code => code).merge(options)
       response = connection.post 'oauth/authorize', params
       results = Hash[URI.decode_www_form(response.body)]
@@ -40,7 +37,8 @@ module Pocket
 
     def access_token_params
       {
-        :consumer_key => consumer_key
+        :consumer_key => consumer_key,
+        :redirect_uri => redirect_uri
       }
     end
   end

--- a/lib/pocket/oauth.rb
+++ b/lib/pocket/oauth.rb
@@ -3,15 +3,15 @@ module Pocket
   module OAuth
     # Return URL for OAuth authorization
     def authorize_url(options={})
-      params = access_token_params.merge(options)
+      params = { redirect_uri: redirect_uri }.merge(options)
       # Pocket renames `code` to `request_token` for some reason in this call
-      params[:request_token] = params[:code]
+      params[:request_token] ||= params.delete(:code)
       connection.build_url("/auth/authorize", params).to_s
     end
 
     # Return a Pocket code
     def get_code(options={})
-      params = access_token_params.merge(options)
+      params = access_token_params.merge(:redirect_uri => redirect_uri).merge(options)
       response = connection.post 'oauth/request', params
       results = Hash[URI.decode_www_form(response.body)]
       code = results['code']


### PR DESCRIPTION
When generating the authorization URL, we shouldn't give away the application's uniq consumer key.

Additionally, make redirect_uri a client-level configuration. It is just-as-static as consumer key, so we shouldn't have to have it replicated multiple times when using the pocket-ruby client.
