### PR TITLE
Updated faraday

### DIFF
--- a/pocket-ruby.gemspec
+++ b/pocket-ruby.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/pocket/version', __FILE__)
 Gem::Specification.new do |s|
   s.add_development_dependency('sinatra', '~> 1.3.3')
   s.add_development_dependency('multi_xml')
-  s.add_runtime_dependency('faraday', ['>= 0.7', '< 0.9'])
-  s.add_runtime_dependency('faraday_middleware', '~> 0.8')
+  s.add_runtime_dependency('faraday', ['>= 0.7'])
+  s.add_runtime_dependency('faraday_middleware', '~> 0.9')
   s.add_runtime_dependency('multi_json', '>= 1.0.3', '~> 1.0')
   s.add_runtime_dependency('hashie',  '>= 0.4.0')
   s.authors = ["Turadg Aleahmad","Jason Ng PT"]


### PR DESCRIPTION
I changed the faraday and faraday_middleware dependencies to use any newer version. I tested retrieving items with the sample server and it seems to work, but I haven't messed with faraday much. Is there any problems with doing this?
